### PR TITLE
Respect the user's environment variable for GOMAXPROCS

### DIFF
--- a/src/loveoneanother.at/tiedot/main.go
+++ b/src/loveoneanother.at/tiedot/main.go
@@ -5,16 +5,23 @@ import (
 	"log"
 	"loveoneanother.at/tiedot/db"
 	"loveoneanother.at/tiedot/srv/v1"
+	"os"
 	"runtime"
+	"strconv"
 )
 
 func main() {
+	var defaultMaxprocs int
+	var err error
+	if defaultMaxprocs, err = strconv.Atoi(os.Getenv("GOMAXPROCS")); err != nil {
+		defaultMaxprocs = runtime.NumCPU() * 2
+	}
 	var mode, dir string
 	var port, maxprocs int
 	flag.StringVar(&mode, "mode", "", "[v1|bench|example]")
 	flag.StringVar(&dir, "dir", "", "database directory")
 	flag.IntVar(&port, "port", 0, "listening port number")
-	flag.IntVar(&maxprocs, "gomaxprocs", runtime.NumCPU()*2, "GOMAXPROCS")
+	flag.IntVar(&maxprocs, "gomaxprocs", defaultMaxprocs, "GOMAXPROCS")
 	flag.Parse()
 
 	if mode == "" {


### PR DESCRIPTION
As a user of your software, if `GOMAXPROCS` exists in my environment, I shouldn't have to pass that in as a command line arg. In the Go ecosystem, this is usually true (see: http://golang.org/doc/faq#Why_no_multi_CPU)

This PR adds a `defaultMaxprocs` which attempts to read from your environment, otherwise, uses `runtime.NumCPU() * 2` as before.
