### PR TITLE
Make dberr.Error thread-safe.

### DIFF
--- a/data/collection.go
+++ b/data/collection.go
@@ -9,6 +9,7 @@ package data
 
 import (
 	"encoding/binary"
+
 	"github.com/HouzuoGuo/tiedot/dberr"
 )
 
@@ -52,7 +53,7 @@ func (col *Collection) Read(id int) []byte {
 func (col *Collection) Insert(data []byte) (id int, err error) {
 	room := len(data) << 1
 	if room > DOC_MAX_ROOM {
-		return 0, dberr.ErrorDocTooLarge.Fault(DOC_MAX_ROOM, room)
+		return 0, dberr.Make(dberr.ErrorDocTooLarge, DOC_MAX_ROOM, room)
 	}
 	id = col.Used
 	docSize := DOC_HEADER + room
@@ -76,15 +77,25 @@ func (col *Collection) Insert(data []byte) (id int, err error) {
 
 // Overwrite or re-insert a document, return the new document ID if re-inserted.
 func (col *Collection) Update(id int, data []byte) (newID int, err error) {
-	if room := len(data); room > DOC_MAX_ROOM {
-		return 0, dberr.ErrorDocTooLarge.Fault(DOC_MAX_ROOM, room)
-	} else if id < 0 || id >= col.Used-DOC_HEADER || col.Buf[id] != 1 {
-		return 0, dberr.ErrorNoDoc.Fault(id)
-	} else if room, _ := binary.Varint(col.Buf[id+1 : id+11]); room > DOC_MAX_ROOM {
-		return 0, dberr.ErrorNoDoc.Fault(id)
-	} else if docEnd := id + DOC_HEADER + int(room); docEnd >= col.Size {
-		return 0, dberr.ErrorNoDoc.Fault(id)
-	} else if len(data) <= int(room) {
+	room := len(data)
+
+	if room > DOC_MAX_ROOM {
+		return 0, dberr.Make(dberr.ErrorDocTooLarge, DOC_MAX_ROOM, room)
+	}
+
+	if id < 0 || id >= col.Used-DOC_HEADER || col.Buf[id] != 1 {
+		return 0, dberr.Make(dberr.ErrorNoDoc, id)
+	}
+
+	if room, _ := binary.Varint(col.Buf[id+1 : id+11]); room > DOC_MAX_ROOM {
+		return 0, dberr.Make(dberr.ErrorNoDoc, id)
+	}
+
+	if docEnd := id + DOC_HEADER + int(room); docEnd >= col.Size {
+		return 0, dberr.Make(dberr.ErrorNoDoc, id)
+	}
+
+	if len(data) <= int(room) {
 		padding := id + DOC_HEADER + len(data)
 		paddingEnd := id + DOC_HEADER + int(room)
 		// Overwrite data and then overwrite padding
@@ -105,13 +116,17 @@ func (col *Collection) Update(id int, data []byte) (newID int, err error) {
 }
 
 // Delete a document by ID.
-func (col *Collection) Delete(id int) (err error) {
+func (col *Collection) Delete(id int) error {
+
 	if id < 0 || id > col.Used-DOC_HEADER || col.Buf[id] != 1 {
-		err = dberr.ErrorNoDoc.Fault(id)
-	} else if col.Buf[id] == 1 {
+		return dberr.Make(dberr.ErrorNoDoc, id)
+	}
+
+	if col.Buf[id] == 1 {
 		col.Buf[id] = 0
 	}
-	return
+
+	return nil
 }
 
 // Run the function on every document; stop when the function returns false.

--- a/data/collection_test.go
+++ b/data/collection_test.go
@@ -1,10 +1,11 @@
 package data
 
 import (
-	"github.com/HouzuoGuo/tiedot/dberr"
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/HouzuoGuo/tiedot/dberr"
 )
 
 func TestInsertRead(t *testing.T) {
@@ -111,7 +112,7 @@ func TestInsertDeleteRead(t *testing.T) {
 		t.Fatalf("Failed to read")
 	}
 	// it shall not panic
-	if err = col.Delete(col.Size); err.(dberr.Error).Code != dberr.DocDoesNotExist {
+	if err = col.Delete(col.Size); dberr.Type(err) != dberr.ErrorNoDoc {
 		t.Fatal("did not error")
 	}
 }
@@ -212,29 +213,29 @@ func TestCollectionGrowAndOutOfBoundAccess(t *testing.T) {
 		t.Fatalf("Read invalid location")
 	}
 	// Update invalid location
-	if _, err := col.Update(1, []byte{}); err.(dberr.Error).Code != dberr.DocDoesNotExist {
+	if _, err := col.Update(1, []byte{}); dberr.Type(err) != dberr.ErrorNoDoc {
 		t.Fatalf("Update invalid location")
 	}
-	if _, err := col.Update(col.Used, []byte{}); err.(dberr.Error).Code != dberr.DocDoesNotExist {
+	if _, err := col.Update(col.Used, []byte{}); dberr.Type(err) != dberr.ErrorNoDoc {
 		t.Fatalf("Update invalid location")
 	}
-	if _, err := col.Update(col.Size, []byte{}); err.(dberr.Error).Code != dberr.DocDoesNotExist {
+	if _, err := col.Update(col.Size, []byte{}); dberr.Type(err) != dberr.ErrorNoDoc {
 		t.Fatalf("Update invalid location")
 	}
-	if _, err := col.Update(999999999, []byte{}); err.(dberr.Error).Code != dberr.DocDoesNotExist {
+	if _, err := col.Update(999999999, []byte{}); dberr.Type(err) != dberr.ErrorNoDoc {
 		t.Fatalf("Update invalid location")
 	}
 	// Delete invalid location
-	if err = col.Delete(1); err.(dberr.Error).Code != dberr.DocDoesNotExist {
+	if err = col.Delete(1); dberr.Type(err) != dberr.ErrorNoDoc {
 		t.Fatal("did not error")
 	}
-	if err = col.Delete(col.Used); err.(dberr.Error).Code != dberr.DocDoesNotExist {
+	if err = col.Delete(col.Used); dberr.Type(err) != dberr.ErrorNoDoc {
 		t.Fatal("did not error")
 	}
-	if err = col.Delete(col.Size); err.(dberr.Error).Code != dberr.DocDoesNotExist {
+	if err = col.Delete(col.Size); dberr.Type(err) != dberr.ErrorNoDoc {
 		t.Fatal("did not error")
 	}
-	if err = col.Delete(999999999); err.(dberr.Error).Code != dberr.DocDoesNotExist {
+	if err = col.Delete(999999999); dberr.Type(err) != dberr.ErrorNoDoc {
 		t.Fatal("did not error")
 	}
 	// Insert - not enough room

--- a/data/partition_test.go
+++ b/data/partition_test.go
@@ -1,12 +1,13 @@
 package data
 
 import (
-	"github.com/HouzuoGuo/tiedot/dberr"
 	"math/rand"
 	"os"
 	"strconv"
 	"testing"
 	"time"
+
+	"github.com/HouzuoGuo/tiedot/dberr"
 )
 
 func TestPartitionDocCRUD(t *testing.T) {
@@ -37,7 +38,7 @@ func TestPartitionDocCRUD(t *testing.T) {
 	if err = part.Update(1, []byte("abcdef")); err != nil {
 		t.Fatal(err)
 	}
-	if err := part.Update(1234, []byte("abcdef")); err.(dberr.Error).Code != dberr.DocDoesNotExist {
+	if err := part.Update(1234, []byte("abcdef")); dberr.Type(err) != dberr.ErrorNoDoc {
 		t.Fatal("Did not error")
 	}
 	if readback, err := part.Read(1); err != nil || string(readback) != "abcdef      " {
@@ -47,17 +48,17 @@ func TestPartitionDocCRUD(t *testing.T) {
 	if err = part.Delete(1); err != nil {
 		t.Fatal(err)
 	}
-	if _, err = part.Read(1); err.(dberr.Error).Code != dberr.DocDoesNotExist {
+	if _, err = part.Read(1); dberr.Type(err) != dberr.ErrorNoDoc {
 		t.Fatal("Did not error")
 	}
-	if err = part.Delete(123); err.(dberr.Error).Code != dberr.DocDoesNotExist {
+	if err = part.Delete(123); dberr.Type(err) != dberr.ErrorNoDoc {
 		t.Fatal("Did not error")
 	}
 	// Lock & unlock
 	if err = part.LockUpdate(123); err != nil {
 		t.Fatal(err)
 	}
-	if err = part.LockUpdate(123); err.(dberr.Error).Code != dberr.DocIsLocked {
+	if err = part.LockUpdate(123); dberr.Type(err) != dberr.ErrorDocLocked {
 		t.Fatal("Did not error")
 	}
 	part.UnlockUpdate(123)

--- a/db/doc_test.go
+++ b/db/doc_test.go
@@ -3,12 +3,13 @@ package db
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/HouzuoGuo/tiedot/dberr"
 	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/HouzuoGuo/tiedot/dberr"
 )
 
 func StrHashTest(t *testing.T) {
@@ -135,7 +136,7 @@ func TestDocCrudAndIdx(t *testing.T) {
 		}
 	}
 	// Read documents and verify index
-	if _, err = col.Read(123456); err.(dberr.Error).Code != dberr.DocDoesNotExist {
+	if _, err = col.Read(123456); dberr.Type(err) != dberr.ErrorNoDoc {
 		t.Fatal("Did not error")
 	}
 	for i, docID := range docIDs {
@@ -147,7 +148,7 @@ func TestDocCrudAndIdx(t *testing.T) {
 		}
 	}
 	// Update document
-	if err = col.Update(654321, map[string]interface{}{}); err.(dberr.Error).Code != dberr.DocDoesNotExist {
+	if err = col.Update(654321, map[string]interface{}{}); dberr.Type(err) != dberr.ErrorNoDoc {
 		t.Fatal("Did not error")
 	}
 	for i, docID := range docIDs {
@@ -175,14 +176,14 @@ func TestDocCrudAndIdx(t *testing.T) {
 		}
 	}
 	// Delete half of those documents
-	if err = col.Delete(654321); err.(dberr.Error).Code != dberr.DocDoesNotExist {
+	if err = col.Delete(654321); dberr.Type(err) != dberr.ErrorNoDoc {
 		t.Fatal("Did not error")
 	}
 	for i := 0; i < numDocs/2+1; i++ {
 		if err := col.Delete(docIDs[i]); err != nil {
 			t.Fatal(err)
 		}
-		if err := col.Delete(docIDs[i]); err.(dberr.Error).Code != dberr.DocDoesNotExist {
+		if err := col.Delete(docIDs[i]); dberr.Type(err) != dberr.ErrorNoDoc {
 			t.Fatal("Did not error")
 		}
 	}
@@ -190,7 +191,7 @@ func TestDocCrudAndIdx(t *testing.T) {
 	for i, docID := range docIDs {
 		if i < numDocs/2+1 {
 			// After delete - verify deleted documents and index
-			if _, err := col.Read(docID); err.(dberr.Error).Code != dberr.DocDoesNotExist {
+			if _, err := col.Read(docID); dberr.Type(err) != dberr.ErrorNoDoc {
 				t.Fatal("Did not delete", i, docID)
 			}
 			if err = idxHasNot(col, []string{"a", "b"}, i*2, docID); err != nil {

--- a/db/query.go
+++ b/db/query.go
@@ -4,10 +4,11 @@ package db
 import (
 	"errors"
 	"fmt"
-	"github.com/HouzuoGuo/tiedot/dberr"
-	"github.com/HouzuoGuo/tiedot/tdlog"
 	"strconv"
 	"strings"
+
+	"github.com/HouzuoGuo/tiedot/dberr"
+	"github.com/HouzuoGuo/tiedot/tdlog"
 )
 
 // Calculate union of sub-query results.
@@ -52,14 +53,14 @@ func Lookup(lookupValue interface{}, expr map[string]interface{}, src *Col, resu
 		} else if _, ok := limit.(int); ok {
 			intLimit = limit.(int)
 		} else {
-			return dberr.ErrorExpectingInt.Fault("limit", limit)
+			return dberr.Make(dberr.ErrorExpectingInt, "limit", limit)
 		}
 	}
 	lookupStrValue := fmt.Sprint(lookupValue) // the value to look for
 	lookupValueHash := StrHash(lookupStrValue)
 	scanPath := strings.Join(vecPath, INDEX_PATH_SEP)
 	if _, indexed := src.indexPaths[scanPath]; !indexed {
-		return dberr.ErrorNeedIndex.Fault(scanPath, expr)
+		return dberr.Make(dberr.ErrorNeedIndex, scanPath, expr)
 	}
 	num := lookupValueHash % src.db.numParts
 	ht := src.hts[num][scanPath]
@@ -98,12 +99,12 @@ func PathExistence(hasPath interface{}, expr map[string]interface{}, src *Col, r
 		} else if _, ok := limit.(int); ok {
 			intLimit = limit.(int)
 		} else {
-			return dberr.ErrorExpectingInt.Fault("limit", limit)
+			return dberr.Make(dberr.ErrorExpectingInt, "limit", limit)
 		}
 	}
 	jointPath := strings.Join(vecPath, INDEX_PATH_SEP)
 	if _, indexed := src.indexPaths[jointPath]; !indexed {
-		return dberr.ErrorNeedIndex.Fault(vecPath, expr)
+		return dberr.Make(dberr.ErrorNeedIndex, vecPath, expr)
 	}
 	counter := 0
 	partDiv := src.approxDocCount(false) / src.db.numParts / 4000 // collect approx. 4k document IDs in each iteration
@@ -156,7 +157,7 @@ func Intersect(subExprs interface{}, src *Col, result *map[int]struct{}) (err er
 			(*result)[docID] = struct{}{}
 		}
 	} else {
-		return dberr.ErrorExpectingSubQuery.Fault(subExprs)
+		return dberr.Make(dberr.ErrorExpectingSubQuery, subExprs)
 	}
 	return
 }
@@ -187,7 +188,7 @@ func Complement(subExprs interface{}, src *Col, result *map[int]struct{}) (err e
 			(*result)[docID] = struct{}{}
 		}
 	} else {
-		return dberr.ErrorExpectingSubQuery.Fault(subExprs)
+		return dberr.Make(dberr.ErrorExpectingSubQuery, subExprs)
 	}
 	return
 }
@@ -223,7 +224,7 @@ func IntRange(intFrom interface{}, expr map[string]interface{}, src *Col, result
 		} else if _, ok := limit.(int); ok {
 			intLimit = limit.(int)
 		} else {
-			return dberr.ErrorExpectingInt.Fault(limit)
+			return dberr.Make(dberr.ErrorExpectingInt, limit)
 		}
 	}
 	// Figure out the range ("from" value & "to" value)
@@ -233,7 +234,7 @@ func IntRange(intFrom interface{}, expr map[string]interface{}, src *Col, result
 	} else if _, ok := intFrom.(int); ok {
 		from = intFrom.(int)
 	} else {
-		return dberr.ErrorExpectingInt.Fault("int-from", from)
+		return dberr.Make(dberr.ErrorExpectingInt, "int-from", from)
 	}
 	if intTo, ok := expr["int-to"]; ok {
 		if floatTo, ok := intTo.(float64); ok {
@@ -241,7 +242,7 @@ func IntRange(intFrom interface{}, expr map[string]interface{}, src *Col, result
 		} else if _, ok := intTo.(int); ok {
 			to = intTo.(int)
 		} else {
-			return dberr.ErrorExpectingInt.Fault("int-to", to)
+			return dberr.Make(dberr.ErrorExpectingInt, "int-to", to)
 		}
 	} else if intTo, ok := expr["int to"]; ok {
 		if floatTo, ok := intTo.(float64); ok {
@@ -249,10 +250,10 @@ func IntRange(intFrom interface{}, expr map[string]interface{}, src *Col, result
 		} else if _, ok := intTo.(int); ok {
 			to = intTo.(int)
 		} else {
-			return dberr.ErrorExpectingInt.Fault("int to", to)
+			return dberr.Make(dberr.ErrorExpectingInt, "int to", to)
 		}
 	} else {
-		return dberr.ErrorMissing.Fault("int-to")
+		return dberr.Make(dberr.ErrorMissing, "int-to")
 	}
 	if to > from && to-from > 1000 || from > to && from-to > 1000 {
 		tdlog.CritNoRepeat("Query %v involves index lookup on more than 1000 values, which can be very inefficient", expr)
@@ -260,7 +261,7 @@ func IntRange(intFrom interface{}, expr map[string]interface{}, src *Col, result
 	counter := int(0) // Number of results already collected
 	htPath := strings.Join(vecPath, ",")
 	if _, indexScan := src.indexPaths[htPath]; !indexScan {
-		return dberr.ErrorNeedIndex.Fault(vecPath, expr)
+		return dberr.Make(dberr.ErrorNeedIndex, vecPath, expr)
 	}
 	if from < to {
 		// Forward scan - from low value to high value
@@ -309,7 +310,7 @@ func evalQuery(q interface{}, src *Col, result *map[int]struct{}, placeSchemaLoc
 			// Might be single document number
 			docID, err := strconv.ParseInt(expr, 10, 64)
 			if err != nil {
-				return dberr.ErrorExpectingInt.Fault("Single Document ID", docID)
+				return dberr.Make(dberr.ErrorExpectingInt, "Single Document ID", docID)
 			}
 			(*result)[int(docID)] = struct{}{}
 		}

--- a/db/query_test.go
+++ b/db/query_test.go
@@ -3,10 +3,11 @@ package db
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/HouzuoGuo/tiedot/dberr"
 	"io/ioutil"
 	"os"
 	"testing"
+
+	"github.com/HouzuoGuo/tiedot/dberr"
 )
 
 func ensureMapHasKeys(m map[int]struct{}, keys ...int) bool {
@@ -117,7 +118,7 @@ func TestQuery(t *testing.T) {
 	}
 	// collection scan
 	q, err = runQuery(`{"eq": 1, "in": ["c"]}`, col)
-	if err.(dberr.Error).Code != dberr.QueryNeedIndex {
+	if dberr.Type(err) != dberr.ErrorNeedIndex {
 		t.Fatal("Collection scan should not happen")
 	}
 	// lookup on "special" (null)
@@ -161,29 +162,29 @@ func TestQuery(t *testing.T) {
 	}
 	// existence test with incorrect input
 	q, err = runQuery(`{"has": ["c"], "limit": "a"}`, col)
-	if err.(dberr.Error).Code != dberr.QueryMalformedInt {
+	if dberr.Type(err) != dberr.ErrorExpectingInt {
 		t.Fatal(err)
 	}
 	// existence test, collection scan & PK
 	q, err = runQuery(`{"has": ["c"], "limit": 2}`, col)
-	if err.(dberr.Error).Code != dberr.QueryNeedIndex {
+	if dberr.Type(err) != dberr.ErrorNeedIndex {
 		t.Fatal("Existence test should return error")
 	}
 	q, err = runQuery(`{"has": ["@id"], "limit": 2}`, col)
-	if err.(dberr.Error).Code != dberr.QueryNeedIndex {
+	if dberr.Type(err) != dberr.ErrorNeedIndex {
 		t.Fatal("Existence test should return error")
 	}
 	// int range scan with incorrect input
 	q, err = runQuery(`{"int-from": "a", "int-to": 4, "in": ["f"], "limit": 1}`, col)
-	if err.(dberr.Error).Code != dberr.QueryMalformedInt {
+	if dberr.Type(err) != dberr.ErrorExpectingInt {
 		t.Fatal(err)
 	}
 	q, err = runQuery(`{"int-from": 1, "int-to": "a", "in": ["f"], "limit": 1}`, col)
-	if err.(dberr.Error).Code != dberr.QueryMalformedInt {
+	if dberr.Type(err) != dberr.ErrorExpectingInt {
 		t.Fatal(err)
 	}
 	q, err = runQuery(`{"int-from": 1, "int-to": 2, "in": ["f"], "limit": "a"}`, col)
-	if err.(dberr.Error).Code != dberr.QueryMalformedInt {
+	if dberr.Type(err) != dberr.ErrorExpectingInt {
 		t.Fatal(err)
 	}
 	// int range scan
@@ -244,7 +245,7 @@ func TestQuery(t *testing.T) {
 	}
 	// intersection with incorrect input
 	q, err = runQuery(`{"c": null}`, col)
-	if err.(dberr.Error).Code != dberr.QueryMissingSubQuery {
+	if dberr.Type(err) != dberr.ErrorExpectingSubQuery {
 		t.Fatal(err)
 	}
 	// complement
@@ -257,7 +258,7 @@ func TestQuery(t *testing.T) {
 	}
 	// complement with incorrect input
 	q, err = runQuery(`{"c": null}`, col)
-	if err.(dberr.Error).Code != dberr.QueryMissingSubQuery {
+	if dberr.Type(err) != dberr.ErrorExpectingSubQuery {
 		t.Fatal(err)
 	}
 	// union of intersection

--- a/example.go
+++ b/example.go
@@ -3,9 +3,10 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"os"
+
 	"github.com/HouzuoGuo/tiedot/db"
 	"github.com/HouzuoGuo/tiedot/dberr"
-	"os"
 )
 
 /*
@@ -99,9 +100,9 @@ func embeddedExample() {
 		panic(err)
 	}
 
-	// More complicated error handing - identify the error kind.
+	// More complicated error handing - identify the error Type.
 	// In this example, the error code tells that the document no longer exists.
-	if err := feeds.Delete(docID); err.(dberr.Error).Code == dberr.DocDoesNotExist {
+	if err := feeds.Delete(docID); dberr.Type(err) == dberr.ErrorNoDoc {
 		fmt.Println("The document was already deleted")
 	}
 

--- a/example_test.go
+++ b/example_test.go
@@ -2,11 +2,12 @@ package main
 
 import (
 	"encoding/json"
-	"github.com/HouzuoGuo/tiedot/db"
-	"github.com/HouzuoGuo/tiedot/dberr"
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/HouzuoGuo/tiedot/db"
+	"github.com/HouzuoGuo/tiedot/dberr"
 )
 
 func sameMap(m1 map[string]interface{}, m2 map[string]interface{}) bool {
@@ -88,7 +89,7 @@ func TestAll(t *testing.T) {
 	if err := feeds.Delete(docID); err != nil {
 		t.Fatal(err)
 	}
-	if err := feeds.Delete(docID); err.(dberr.Error).Code != dberr.DocDoesNotExist {
+	if err := feeds.Delete(docID); dberr.Type(err) != dberr.ErrorNoDoc {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
Today I learned that the initial error mechanism that I wrote for tiedot isn't treadsafe and multiple goroutiens calling `dberr.Error.Error()` would result in a race and ended up with a crash.

I have refactored the code to make it threadsafe.

I have also refactored out the `dberr.Error.Code` as it seem pretty redundent to me. If you think they can be helpful, It should be very easy to reintroduce them and add a `dberr.Code(e error) int` to handle them similar to `dberr.Type`.

Please revivew the code and let me know if anything can be improved.
