### PR TITLE
Add a GetAll() method to httpapi/document

### DIFF
--- a/httpapi/jwt.go
+++ b/httpapi/jwt.go
@@ -243,6 +243,7 @@ func ServeJWTEnabledEndpoints(jwtPubKey, jwtPrivateKey string) {
 	http.HandleFunc("/insert", jwtWrap(Insert))
 	http.HandleFunc("/get", jwtWrap(Get))
 	http.HandleFunc("/getpage", jwtWrap(GetPage))
+	http.HandleFunc("/getall", jwtWrap(GetAll))
 	http.HandleFunc("/update", jwtWrap(Update))
 	http.HandleFunc("/delete", jwtWrap(Delete))
 	http.HandleFunc("/approxdoccount", jwtWrap(ApproxDocCount))

--- a/httpapi/srv.go
+++ b/httpapi/srv.go
@@ -77,6 +77,7 @@ func ServeEndpoints() {
 	http.HandleFunc("/insert", Insert)
 	http.HandleFunc("/get", Get)
 	http.HandleFunc("/getpage", GetPage)
+	http.HandleFunc("/getall", GetAll)
 	http.HandleFunc("/update", Update)
 	http.HandleFunc("/delete", Delete)
 	http.HandleFunc("/approxdoccount", ApproxDocCount)


### PR DESCRIPTION
To allow easy retrieval of all documents in a given collection, add a GetAll() method to httpapi/document as well as matching endpoints for both jwt and srv.

Using this new method/endpoint makes it much more straightforward to retrieve all documents:
    curl 'http://localhost:8080/getall?col=Feeds'

vice two calls, something like:
    count=$(curl 'http://localhost:8080/approxdoccount?col=Feed')
    curl 'http://localhost:8080/getpage?col=Feed&page=0&total='$((count + 1))