### PR TITLE
Addition of two new optional flags: bind, authtoken

### DIFF
--- a/httpapi/auth.go
+++ b/httpapi/auth.go
@@ -1,0 +1,63 @@
+/*
+This package enables the use of a token-based Authorization header.
+
+In order for requests to be valid, clients must set the following request header:
+    "Authorization: token TOKEN"
+where TOKEN is the value set via the -authtoken flag in the command line.
+
+Server usage example:
+    tiedot -mode=httpd -dir=tmp/db -authtoken=abc123
+
+Client request example:
+    curl -I -H "Authorization: token abc123" http://127.0.0.1:8080/all
+*/
+
+package httpapi
+
+import (
+	"github.com/HouzuoGuo/tiedot/tdlog"
+	"net/http"
+)
+
+var authToken string
+
+// Enable Authorization header check on the HTTP handler function.
+func authWrap(originalHandler http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if "token "+authToken != r.Header.Get("Authorization") {
+			http.Error(w, "", http.StatusUnauthorized)
+			return
+		}
+		originalHandler(w, r)
+	}
+}
+
+func ServeAuthTokenEndpoints(token string) {
+	authToken = token
+	// collection management (stop-the-world)
+	http.HandleFunc("/create", authWrap(Create))
+	http.HandleFunc("/rename", authWrap(Rename))
+	http.HandleFunc("/drop", authWrap(Drop))
+	http.HandleFunc("/all", authWrap(All))
+	http.HandleFunc("/scrub", authWrap(Scrub))
+	http.HandleFunc("/sync", authWrap(Sync))
+	// query
+	http.HandleFunc("/query", authWrap(Query))
+	http.HandleFunc("/count", authWrap(Count))
+	// document management
+	http.HandleFunc("/insert", authWrap(Insert))
+	http.HandleFunc("/get", authWrap(Get))
+	http.HandleFunc("/getpage", authWrap(GetPage))
+	http.HandleFunc("/update", authWrap(Update))
+	http.HandleFunc("/delete", authWrap(Delete))
+	http.HandleFunc("/approxdoccount", authWrap(ApproxDocCount))
+	// index management (stop-the-world)
+	http.HandleFunc("/index", authWrap(Index))
+	http.HandleFunc("/indexes", authWrap(Indexes))
+	http.HandleFunc("/unindex", authWrap(Unindex))
+	// misc
+	http.HandleFunc("/shutdown", authWrap(Shutdown))
+	http.HandleFunc("/dump", authWrap(Dump))
+
+	tdlog.Noticef("API endpoints now require the 'Authorization: token' header.")
+}

--- a/main.go
+++ b/main.go
@@ -65,9 +65,13 @@ func main() {
 	flag.BoolVar(&debug, "debug", false, "Dump goroutine stack traces upon receiving interrupt signal")
 	// HTTP mode params
 	var dir string
+	var bind string
 	var port int
+	var authToken string
 	var tlsCrt, tlsKey string
 	flag.StringVar(&dir, "dir", "", "(HTTP server) database directory")
+	flag.StringVar(&bind, "bind", "", "(HTTP server) bind to IP address (all network interfaces by default)")
+	flag.StringVar(&authToken, "authtoken", "", "(HTTP server) auth token. Requests without this token in the 'Authorization: token TOKEN' request header will be rejected. (empty to disable)")
 	flag.IntVar(&port, "port", 8080, "(HTTP server) port number")
 	flag.StringVar(&tlsCrt, "tlscrt", "", "(HTTP server) TLS certificate (empty to disable TLS).")
 	flag.StringVar(&tlsKey, "tlskey", "", "(HTTP server) TLS certificate key (empty to disable TLS).")
@@ -139,7 +143,7 @@ func main() {
 			tdlog.Notice("To enable JWT, please specify RSA private and public key.")
 			os.Exit(1)
 		}
-		httpapi.Start(dir, port, tlsCrt, tlsKey, jwtPubKey, jwtPrivateKey)
+		httpapi.Start(dir, port, tlsCrt, tlsKey, jwtPubKey, jwtPrivateKey, bind, authToken)
 	case "example":
 		// Run embedded usage examples
 		embeddedExample()


### PR DESCRIPTION
Addition of two new optional flags:
-bind: let's you bind to a specific (single) interface
-authtoken: enables the requirement of a 'Authorization: token' request header