### PR TITLE
Improve Continuous Integration and fix some trivial Golint suggestions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: go
+go_import_path: github.com/HouzuoGuo/tiedot
 sudo: false
 go:
   - 1.4.3
@@ -12,3 +13,6 @@ matrix:
     - go: tip
 install:
   - go get github.com/dgrijalva/jwt-go
+scritp:
+ - go build
+ - go test -v ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,14 @@
 language: go
-
 sudo: false
-
 go:
+  - 1.4.3
+  - 1.5.3
   - tip
+os:
+  - linux
+  - osx
+matrix:
+  allow_failures:
+    - go: tip
+install:
+  - go get github.com/dgrijalva/jwt-go

--- a/benchmark.go
+++ b/benchmark.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/HouzuoGuo/tiedot/db"
 	"math/rand"
 	"os"
 	"runtime"
@@ -11,6 +10,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/HouzuoGuo/tiedot/db"
 )
 
 // Whether to clean up (delete benchmark DB) after benchmark

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"github.com/HouzuoGuo/tiedot/db"
 	"math/rand"
 	"os"
 	"runtime"
@@ -11,6 +10,8 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/HouzuoGuo/tiedot/db"
 )
 
 var benchTestSize = 100000

--- a/data/collection.go
+++ b/data/collection.go
@@ -1,10 +1,17 @@
-/*
-Collection data file contains document data. Every document has a binary header and UTF-8 text content.
-Documents are inserted one after another, and occupies 2x original document size to leave room for future updates.
-Deleted documents are marked as deleted and the space is irrecoverable until a "scrub" action (in DB logic) is carried out.
-When update takes place, the new document may overwrite original document if there is enough space, otherwise the
-original document is marked as deleted and the updated document is inserted as a new document.
-*/
+// Collection data file contains document data.
+//
+// Every document has a binary header and UTF-8 text content.
+//
+// Documents are inserted one after another, and occupies 2x original document
+// size to leave room for future updates.
+//
+// Deleted documents are marked as deleted and the space is irrecoverable until
+// a "scrub" action (in DB logic) is carried out.
+//
+// When update takes place, the new document may overwrite original document if
+// there is enough space, otherwise the original document is marked as deleted
+// and the updated document is inserted as a new document.
+
 package data
 
 import (
@@ -104,11 +111,11 @@ func (col *Collection) Update(id int, data []byte) (newID int, err error) {
 			copy(col.Buf[padding:padding+copySize], PADDING)
 		}
 		return id, nil
-	} else {
-		// No enough room - re-insert the document
-		col.Delete(id)
-		return col.Insert(data)
 	}
+
+	// No enough room - re-insert the document
+	col.Delete(id)
+	return col.Insert(data)
 }
 
 // Delete a document by ID.

--- a/data/file.go
+++ b/data/file.go
@@ -1,4 +1,5 @@
 // Common data file features - enlarge, close, close, etc.
+
 package data
 
 import (

--- a/data/file.go
+++ b/data/file.go
@@ -3,9 +3,10 @@
 package data
 
 import (
+	"os"
+
 	"github.com/HouzuoGuo/tiedot/gommap"
 	"github.com/HouzuoGuo/tiedot/tdlog"
-	"os"
 )
 
 // Data file keeps track of the amount of total and used space.

--- a/data/hashtable.go
+++ b/data/hashtable.go
@@ -1,10 +1,14 @@
-/*
-Hash table file contains binary content; it implements a static hash table made of hash buckets and integer entries.
-Every bucket has a fixed number of entries. When a bucket becomes full, a new bucket is chained to it in order to store
-more entries. Every entry has an integer key and value.
-An entry key may have multiple values assigned to it, however the combination of entry key and value must be unique
-across the entire hash table.
-*/
+// Hash table file contains binary content.
+//
+// This package implements a static hash table made of hash buckets and integer
+// entries.
+//
+// Every bucket has a fixed number of entries. When a bucket becomes full, a new
+// bucket is chained to it in order to store more entries. Every entry has an
+// integer key and value. An entry key may have multiple values assigned to it,
+// however the combination of entry key and value must be unique across the
+// entire hash table.
+
 package data
 
 import (
@@ -204,10 +208,10 @@ func GetPartitionRange(partNum, totalParts int) (start int, end int) {
 	start = partNum * perPart
 	if leftOver > 0 {
 		if partNum == 0 {
-			end += 1
+			end++
 		} else if partNum < leftOver {
 			start += partNum
-			end += 1
+			end++
 		} else {
 			start += leftOver
 		}

--- a/data/hashtable.go
+++ b/data/hashtable.go
@@ -13,8 +13,9 @@ package data
 
 import (
 	"encoding/binary"
-	"github.com/HouzuoGuo/tiedot/tdlog"
 	"sync"
+
+	"github.com/HouzuoGuo/tiedot/tdlog"
 )
 
 const (

--- a/data/partition.go
+++ b/data/partition.go
@@ -1,8 +1,8 @@
-/*
-(Collection) Partition is a collection data file accompanied by a hash table in order to allow addressing of a
-document using an unchanging ID:
-The hash table stores the unchanging ID as entry key and the physical document location as entry value.
-*/
+// (Collection) Partition is a collection data file accompanied by a hash table
+// in order to allow addressing of a document using an unchanging ID:
+// The hash table stores the unchanging ID as entry key and the physical
+// document location as entry value.
+
 package data
 
 import (

--- a/db/col.go
+++ b/db/col.go
@@ -5,12 +5,13 @@ package db
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/HouzuoGuo/tiedot/data"
 	"io/ioutil"
 	"os"
 	"path"
 	"strconv"
 	"strings"
+
+	"github.com/HouzuoGuo/tiedot/data"
 )
 
 const (

--- a/db/col.go
+++ b/db/col.go
@@ -1,4 +1,5 @@
-/* Collection schema and index management. */
+// Collection schema and index management.
+
 package db
 
 import (

--- a/db/db.go
+++ b/db/db.go
@@ -5,7 +5,6 @@ package db
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/HouzuoGuo/tiedot/tdlog"
 	"io"
 	"io/ioutil"
 	"math/rand"
@@ -17,6 +16,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/HouzuoGuo/tiedot/tdlog"
 )
 
 const (

--- a/db/db.go
+++ b/db/db.go
@@ -1,4 +1,5 @@
-/* Collection and DB storage management. */
+// Collection and DB storage management.
+
 package db
 
 import (
@@ -115,7 +116,7 @@ func (db *DB) AllCols() (ret []string) {
 	db.schemaLock.RLock()
 	defer db.schemaLock.RUnlock()
 	ret = make([]string, 0, len(db.cols))
-	for name, _ := range db.cols {
+	for name := range db.cols {
 		ret = append(ret, name)
 	}
 	return

--- a/db/doc.go
+++ b/db/doc.go
@@ -1,4 +1,5 @@
-/* Document management and index maintenance. */
+// Document management and index maintenance.
+
 package db
 
 import (

--- a/db/doc.go
+++ b/db/doc.go
@@ -5,8 +5,9 @@ package db
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/HouzuoGuo/tiedot/tdlog"
 	"math/rand"
+
+	"github.com/HouzuoGuo/tiedot/tdlog"
 )
 
 // Resolve the attribute(s) in the document structure along the given path.

--- a/db/query.go
+++ b/db/query.go
@@ -1,4 +1,5 @@
-/* Query processor. */
+// Query processor.
+
 package db
 
 import (
@@ -145,7 +146,7 @@ func Intersect(subExprs interface{}, src *Col, result *map[int]struct{}) (err er
 				myResult = subResult
 				first = false
 			} else {
-				for k, _ := range subResult {
+				for k := range subResult {
 					if _, inBoth := myResult[k]; inBoth {
 						intersection[k] = struct{}{}
 					}
@@ -172,12 +173,12 @@ func Complement(subExprs interface{}, src *Col, result *map[int]struct{}) (err e
 			if err = evalQuery(subExpr, src, &subResult, false); err != nil {
 				return
 			}
-			for k, _ := range subResult {
+			for k := range subResult {
 				if _, inBoth := myResult[k]; !inBoth {
 					complement[k] = struct{}{}
 				}
 			}
-			for k, _ := range myResult {
+			for k := range myResult {
 				if _, inBoth := subResult[k]; !inBoth {
 					complement[k] = struct{}{}
 				}
@@ -273,7 +274,7 @@ func IntRange(intFrom interface{}, expr map[string]interface{}, src *Col, result
 				if intLimit > 0 && counter == intLimit {
 					break
 				}
-				counter += 1
+				counter++
 				(*result)[docID] = struct{}{}
 			}
 		}
@@ -287,7 +288,7 @@ func IntRange(intFrom interface{}, expr map[string]interface{}, src *Col, result
 				if intLimit > 0 && counter == intLimit {
 					break
 				}
-				counter += 1
+				counter++
 				(*result)[docID] = struct{}{}
 			}
 		}
@@ -306,14 +307,13 @@ func evalQuery(q interface{}, src *Col, result *map[int]struct{}, placeSchemaLoc
 	case string:
 		if expr == "all" {
 			return EvalAllIDs(src, result)
-		} else {
-			// Might be single document number
-			docID, err := strconv.ParseInt(expr, 10, 64)
-			if err != nil {
-				return dberr.New(dberr.ErrorExpectingInt, "Single Document ID", docID)
-			}
-			(*result)[int(docID)] = struct{}{}
 		}
+		// Might be single document number
+		docID, err := strconv.ParseInt(expr, 10, 64)
+		if err != nil {
+			return dberr.New(dberr.ErrorExpectingInt, "Single Document ID", docID)
+		}
+		(*result)[int(docID)] = struct{}{}
 	case map[string]interface{}:
 		if lookupValue, lookup := expr["eq"]; lookup { // eq - lookup
 			return Lookup(lookupValue, expr, src, result)

--- a/db/query_test.go
+++ b/db/query_test.go
@@ -262,17 +262,17 @@ func TestQuery(t *testing.T) {
 		t.Fatal(err)
 	}
 	// union of intersection
-	q, err = runQuery(`[{"n": [{"eq": 3, "in": ["c"]}]}, {"n": [{"eq": 2, "in": ["c"]}]}]`, col)
+	q, _ = runQuery(`[{"n": [{"eq": 3, "in": ["c"]}]}, {"n": [{"eq": 2, "in": ["c"]}]}]`, col)
 	if !ensureMapHasKeys(q, ids[2], ids[3]) {
 		t.Fatal(q)
 	}
 	// union of complement
-	q, err = runQuery(`[{"c": [{"eq": 3, "in": ["c"]}]}, {"c": [{"eq": 2, "in": ["c"]}]}]`, col)
+	q, _ = runQuery(`[{"c": [{"eq": 3, "in": ["c"]}]}, {"c": [{"eq": 2, "in": ["c"]}]}]`, col)
 	if !ensureMapHasKeys(q, ids[2], ids[3]) {
 		t.Fatal(q)
 	}
 	// union of complement of intersection
-	q, err = runQuery(`[{"c": [{"n": [{"eq": 1, "in": ["d"]},{"eq": 1, "in": ["c"]}]},{"eq": 1, "in": ["d"]}]},{"eq": 2, "in": ["c"]}]`, col)
+	q, _ = runQuery(`[{"c": [{"n": [{"eq": 1, "in": ["d"]},{"eq": 1, "in": ["c"]}]},{"eq": 1, "in": ["d"]}]},{"eq": 2, "in": ["c"]}]`, col)
 	if !ensureMapHasKeys(q, ids[2], ids[4], ids[5]) {
 		t.Fatal(q)
 	}

--- a/httpapi/collection.go
+++ b/httpapi/collection.go
@@ -1,4 +1,5 @@
-/* Collection management handlers. */
+// Collection management handlers.
+
 package httpapi
 
 import (

--- a/httpapi/document.go
+++ b/httpapi/document.go
@@ -1,4 +1,5 @@
-/* Document management handlers. */
+// Document management handlers.
+
 package httpapi
 
 import (

--- a/httpapi/index.go
+++ b/httpapi/index.go
@@ -1,4 +1,5 @@
-/* Index management handlers. */
+// Index management handlers.
+
 package httpapi
 
 import (

--- a/httpapi/jwt.go
+++ b/httpapi/jwt.go
@@ -136,7 +136,7 @@ func getJWT(w http.ResponseWriter, r *http.Request) {
 	}
 	// Verify password
 	pass := r.FormValue(JWT_PASS_ATTR)
-	for recID, _ := range userQueryResult {
+	for recID := range userQueryResult {
 		rec, err := jwtCol.Read(recID)
 		if err != nil {
 			break

--- a/httpapi/misc.go
+++ b/httpapi/misc.go
@@ -1,4 +1,5 @@
-/* Miscellaneous function handlers. */
+// Miscellaneous function handlers.
+
 package httpapi
 
 import (

--- a/httpapi/query.go
+++ b/httpapi/query.go
@@ -1,4 +1,5 @@
-/* Query handlers. */
+// Query handlers.
+
 package httpapi
 
 import (

--- a/httpapi/query.go
+++ b/httpapi/query.go
@@ -5,9 +5,10 @@ package httpapi
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/HouzuoGuo/tiedot/db"
 	"net/http"
 	"strconv"
+
+	"github.com/HouzuoGuo/tiedot/db"
 )
 
 // Execute a query and return documents from the result.

--- a/httpapi/srv.go
+++ b/httpapi/srv.go
@@ -15,6 +15,7 @@ Access to specific endpoints are granted explicitly to each user.
 
 These API endpoints will never require authorization: / (root), /version, and /memstats
 */
+
 package httpapi
 
 import (

--- a/httpapi/srv.go
+++ b/httpapi/srv.go
@@ -20,10 +20,11 @@ package httpapi
 
 import (
 	"fmt"
-	"github.com/HouzuoGuo/tiedot/db"
-	"github.com/HouzuoGuo/tiedot/tdlog"
 	"io/ioutil"
 	"net/http"
+
+	"github.com/HouzuoGuo/tiedot/db"
+	"github.com/HouzuoGuo/tiedot/tdlog"
 )
 
 var (

--- a/main.go
+++ b/main.go
@@ -118,7 +118,7 @@ func main() {
 		c := make(chan os.Signal, 1)
 		signal.Notify(c, os.Interrupt)
 		go func() {
-			for _ = range c {
+			for range c {
 				pprof.Lookup("goroutine").WriteTo(os.Stderr, 1)
 			}
 		}()

--- a/main.go
+++ b/main.go
@@ -3,8 +3,6 @@ package main
 
 import (
 	"flag"
-	"github.com/HouzuoGuo/tiedot/httpapi"
-	"github.com/HouzuoGuo/tiedot/tdlog"
 	"io/ioutil"
 	"os"
 	"os/signal"
@@ -12,6 +10,9 @@ import (
 	"runtime/pprof"
 	"strconv"
 	"strings"
+
+	"github.com/HouzuoGuo/tiedot/httpapi"
+	"github.com/HouzuoGuo/tiedot/tdlog"
 )
 
 // Read Linux system VM parameters and print performance configuration advice when necessary.

--- a/main.go
+++ b/main.go
@@ -1,4 +1,4 @@
-/* Run tiedot HTTP API server, benchmarks, or embedded usage example. */
+// Run tiedot HTTP API server, benchmarks, or embedded usage example.
 package main
 
 import (

--- a/rsa_test.go
+++ b/rsa_test.go
@@ -1,10 +1,11 @@
 package main
 
 import (
-	jwt "github.com/dgrijalva/jwt-go"
 	"io/ioutil"
 	"testing"
 	"time"
+
+	jwt "github.com/dgrijalva/jwt-go"
 )
 
 var (


### PR DESCRIPTION
- (goling) Fixed malformed comments;
- (goling) Removed useless / redundant branching from 'if' statements;
- (goling) Rewrote code to use ++ unary operators;
- (goling) Removed redundant empty variables from 'range' statements;
- (go vet) Removed unused variables 'err' (but assigned)
- Apply gofmt;
- Apply goimports;
- Updated .travis.yml to use stable versions of Golang other than -tip;
- Added MacOS X to .travis.yml;