### PR TITLE
Always acquire lock for updating given document

### DIFF
--- a/dberr/errors.go
+++ b/dberr/errors.go
@@ -14,7 +14,6 @@ const (
 
 	// Document errors
 	ErrorDocTooLarge errorType = "Document is too large. Max: `%d`, Given: `%d`"
-	ErrorDocLocked   errorType = "Document `%d` is locked for update - try again later"
 
 	// Query input errors
 	ErrorNeedIndex         errorType = "Please index %v and retry query %v."


### PR DESCRIPTION
- simplify code for access of given document;
- simplify concurrent update;
- greatly improve possibility for further update improvements (#111);
- fix #112;
- does not decrease performance of `tiedot -mode=bench` on my machine.