### PR TITLE
Add original_content-aware updates

### DIFF
--- a/db/doc_test.go
+++ b/db/doc_test.go
@@ -259,7 +259,7 @@ func TestDocCrudAndIdx(t *testing.T) {
 		t.Fatal("Approximate is way off", col.ApproxDocCount())
 	}
 
-	// Read back all documents page by pabe
+	// Read back all documents page by page
 	totalPage := col.ApproxDocCount() / 100
 	collectedIDs := make(map[int]struct{})
 	for page := 0; page < totalPage; page++ {

--- a/httpapi/jwt.go
+++ b/httpapi/jwt.go
@@ -39,6 +39,7 @@ import (
 	"time"
 
 	"crypto/rsa"
+
 	"github.com/HouzuoGuo/tiedot/db"
 	"github.com/HouzuoGuo/tiedot/tdlog"
 	jwt "github.com/dgrijalva/jwt-go"


### PR DESCRIPTION
Two new functions UpdateFunc and UpdateBytesFunc added.
They introduce ability to make updates based on previous/original data (instead of simple override).
Simple use case is to increment some field atomically.

UpdateBytesFunc bases on plain []byte content;
UpdateFunc is using map[string]interface{} - as other db.* functions.

Fix #111.
---
improve performance of standard Update a bit as a bonus (2nd commit) ~ 10% on my machine.