### PR TITLE
Added Config json file allowing data constants to be configured

### DIFF
--- a/data/config.go
+++ b/data/config.go
@@ -1,0 +1,93 @@
+package data
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+)
+
+var dataConf dataConfig
+
+// Collection config holds configuration data for Collections
+type dataConfig struct {
+	DocMaxRoom     int
+	DocHeader      int
+	Padding        string
+	ColFileGrowth  int
+	LenPadding     int `json:"-"`
+	EntrySize      int
+	BucketHeader   int
+	PerBucket      int
+	BucketSize     int `json:"-"`
+	HTFileGrowth   int
+	HashBits       uint
+	InitialBuckets int
+}
+
+func InitDataConfig(path string) (err error) {
+	var file *os.File
+	var j []byte
+
+	if err := os.MkdirAll(path, 0700); err != nil {
+		return err
+	}
+
+	filePath := fmt.Sprintf("%s/data-config.json", path)
+
+	// set the default dataConfig
+	dataConf = dataConfig{
+		DocMaxRoom:     2 * 1048576,
+		DocHeader:      1 + 10,
+		Padding:        strings.Repeat(" ", 128),
+		ColFileGrowth:  COL_FILE_GROWTH,
+		EntrySize:      1 + 10 + 10,
+		BucketHeader:   10,
+		PerBucket:      16,
+		HTFileGrowth:   HT_FILE_GROWTH,
+		HashBits:       HASH_BITS,
+		InitialBuckets: INITIAL_BUCKETS,
+	}
+
+	// try to open the file
+	if file, err = os.OpenFile(filePath, os.O_RDONLY, 0644); err != nil {
+		if _, ok := err.(*os.PathError); ok {
+			// if we could not find the file because it doesn't exist, lets create it
+			// so the database always runs with these settings
+			err = nil
+
+			if file, err = os.OpenFile(filePath, os.O_CREATE|os.O_WRONLY, 0644); err != nil {
+				return
+			}
+
+			j, err = json.MarshalIndent(&dataConf, "", "  ")
+			if err != nil {
+				return
+			}
+
+			if _, err = file.Write(j); err != nil {
+				return
+			}
+
+		} else {
+			return
+		}
+	} else {
+		// if we find the file we will leave it as it is and merge
+		// it into the default
+		var b []byte
+		if b, err = ioutil.ReadAll(file); err != nil {
+			return
+		}
+
+		if err = json.Unmarshal(b, &dataConf); err != nil {
+			return
+		}
+	}
+
+	dataConf.LenPadding = len(dataConf.Padding)
+	dataConf.BucketSize = dataConf.BucketHeader + dataConf.PerBucket*dataConf.EntrySize
+
+	return
+}

--- a/data/config_test.go
+++ b/data/config_test.go
@@ -1,0 +1,135 @@
+package data
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+)
+
+/*
+Set up the configs without a file
+*/
+func TestEmtpyJsonConfig(t *testing.T) {
+	config := dataConfig{
+		DocMaxRoom:     2 * 1048576,
+		DocHeader:      1 + 10,
+		Padding:        strings.Repeat(" ", 128),
+		ColFileGrowth:  COL_FILE_GROWTH,
+		EntrySize:      1 + 10 + 10,
+		BucketHeader:   10,
+		PerBucket:      16,
+		HTFileGrowth:   HT_FILE_GROWTH,
+		HashBits:       HASH_BITS,
+		InitialBuckets: INITIAL_BUCKETS,
+	}
+
+	tmp := "/tmp/tiedot_config_test_empty"
+	os.Remove(tmp)
+	defer os.Remove(tmp)
+
+	if err := assertCorrectConfig(tmp, config); err != nil {
+		t.Fatal(err)
+	}
+}
+
+/*
+  Set up the configs when there is already a file
+*/
+func TestConfiguredJsonConfig(t *testing.T) {
+	config := dataConfig{
+		DocMaxRoom:     1048576,
+		DocHeader:      1 + 10,
+		Padding:        strings.Repeat(" ", 128),
+		ColFileGrowth:  4194304,
+		EntrySize:      1 + 10 + 10,
+		BucketHeader:   10,
+		PerBucket:      16,
+		HTFileGrowth:   1048576,
+		HashBits:       11,
+		InitialBuckets: 2048,
+	}
+
+	tmp := "/tmp/tiedot_config_test_configured"
+	os.Remove(tmp)
+	defer os.Remove(tmp)
+
+	if err := os.MkdirAll(tmp, 0700); err != nil {
+		t.Fatal(err)
+	}
+
+	f, err := os.OpenFile(fmt.Sprintf("%s/data-config.json", tmp), os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = f.Write([]byte(`{"DocMaxRoom": 1048576,"ColFileGrowth": 4194304,"HTFileGrowth": 1048576,"HashBits": 11,"InitialBuckets": 2048}`))
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	f.Close()
+
+	if err := assertCorrectConfig(tmp, config); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func assertCorrectConfig(path string, assertConfig dataConfig) (err error) {
+	// Start by making sure an empty initializion works
+	if err = InitDataConfig(path); err != nil {
+		fmt.Print("one")
+		return
+	}
+
+	if err = assertConfigsEqual(dataConf, assertConfig); err != nil {
+		return
+	}
+
+	return
+}
+
+func assertConfigsEqual(c1, c2 dataConfig) error {
+	if c1.DocMaxRoom != c2.DocMaxRoom {
+		return fmt.Errorf("DocMaxRoom configs differ %s != %s", c1.DocMaxRoom, c2.DocMaxRoom)
+	}
+
+	if c1.DocHeader != c2.DocHeader {
+		return fmt.Errorf("DocHeader configs differ %s != %s", c1.DocHeader, c2.DocHeader)
+	}
+
+	if c1.Padding != c2.Padding {
+		return fmt.Errorf("Padding configs differ %s != %s", c1.Padding, c2.Padding)
+	}
+
+	if c1.ColFileGrowth != c2.ColFileGrowth {
+		return fmt.Errorf("ColFileGrowth configs differ %s != %s", c1.ColFileGrowth, c2.ColFileGrowth)
+	}
+
+	if c1.EntrySize != c2.EntrySize {
+		return fmt.Errorf("EntrySize configs differ %s != %s", c1.EntrySize, c2.EntrySize)
+	}
+
+	if c1.BucketHeader != c2.BucketHeader {
+		return fmt.Errorf("BucketHeader configs differ %s != %s", c1.BucketHeader, c2.BucketHeader)
+	}
+
+	if c1.PerBucket != c2.PerBucket {
+		return fmt.Errorf("PerBucket configs differ %s != %s", c1.PerBucket, c2.PerBucket)
+	}
+
+	if c1.HashBits != c2.HashBits {
+		return fmt.Errorf("HashBits configs differ %s != %s", c1.HashBits, c2.HashBits)
+	}
+
+	if c1.HTFileGrowth != c2.HTFileGrowth {
+		return fmt.Errorf("HTFileGrowth configs differ %s != %s", c1.HTFileGrowth, c2.HTFileGrowth)
+	}
+
+	if c1.InitialBuckets != c2.InitialBuckets {
+		return fmt.Errorf("InitialBuckets configs differ %s != %s", c1.InitialBuckets, c2.InitialBuckets)
+	}
+
+	return nil
+}

--- a/data/hash32.go
+++ b/data/hash32.go
@@ -10,5 +10,5 @@ const (
 
 // Return the portion (first HASH_BITS bytes) used for allocating the entry. The integer smearing process does not apply to 32-bit system.
 func HashKey(key int) int {
-	return key & ((1 << HASH_BITS) - 1)
+	return key & ((1 << dataConf.HashBits) - 1)
 }

--- a/data/hash64.go
+++ b/data/hash64.go
@@ -15,5 +15,5 @@ func HashKey(key int) int {
 	key = (key ^ 0xdeadbeef) + (key << 5)
 	key = key ^ (key >> 11)
 	// ========== Integer-smear end =========
-	return key & ((1 << HASH_BITS) - 1)
+	return key & ((1 << dataConf.HashBits) - 1)
 }

--- a/data/hashtable.go
+++ b/data/hashtable.go
@@ -18,13 +18,6 @@ import (
 	"github.com/HouzuoGuo/tiedot/tdlog"
 )
 
-const (
-	ENTRY_SIZE    = 1 + 10 + 10                           // Hash entry size: validity (single byte), key (int 10 bytes), value (int 10 bytes)
-	BUCKET_HEADER = 10                                    // Bucket header size: next chained bucket number (int 10 bytes)
-	PER_BUCKET    = 16                                    // Entries per bucket
-	BUCKET_SIZE   = BUCKET_HEADER + PER_BUCKET*ENTRY_SIZE // Size of a bucket
-)
-
 // Hash table file is a binary file containing buckets of hash entries.
 type HashTable struct {
 	*DataFile
@@ -35,7 +28,7 @@ type HashTable struct {
 // Open a hash table file.
 func OpenHashTable(path string) (ht *HashTable, err error) {
 	ht = &HashTable{Lock: new(sync.RWMutex)}
-	if ht.DataFile, err = OpenDataFile(path, HT_FILE_GROWTH); err != nil {
+	if ht.DataFile, err = OpenDataFile(path, dataConf.HTFileGrowth); err != nil {
 		return
 	}
 	ht.calculateNumBuckets()
@@ -44,16 +37,16 @@ func OpenHashTable(path string) (ht *HashTable, err error) {
 
 // Follow the longest bucket chain to calculate total number of buckets, hence the "used size" of hash table file.
 func (ht *HashTable) calculateNumBuckets() {
-	ht.numBuckets = ht.Size / BUCKET_SIZE
-	largestBucketNum := INITIAL_BUCKETS - 1
-	for i := 0; i < INITIAL_BUCKETS; i++ {
+	ht.numBuckets = ht.Size / dataConf.BucketSize
+	largestBucketNum := dataConf.InitialBuckets - 1
+	for i := 0; i < dataConf.InitialBuckets; i++ {
 		lastBucket := ht.lastBucket(i)
 		if lastBucket > largestBucketNum && lastBucket < ht.numBuckets {
 			largestBucketNum = lastBucket
 		}
 	}
 	ht.numBuckets = largestBucketNum + 1
-	usedSize := ht.numBuckets * BUCKET_SIZE
+	usedSize := ht.numBuckets * dataConf.BucketSize
 	if usedSize > ht.Size {
 		ht.Used = ht.Size
 		ht.EnsureSize(usedSize - ht.Used)
@@ -67,12 +60,12 @@ func (ht *HashTable) nextBucket(bucket int) int {
 	if bucket >= ht.numBuckets {
 		return 0
 	}
-	bucketAddr := bucket * BUCKET_SIZE
+	bucketAddr := bucket * dataConf.BucketSize
 	nextUint, err := binary.Varint(ht.Buf[bucketAddr : bucketAddr+10])
 	next := int(nextUint)
 	if next == 0 {
 		return 0
-	} else if err < 0 || next <= bucket || next >= ht.numBuckets || next < INITIAL_BUCKETS {
+	} else if err < 0 || next <= bucket || next >= ht.numBuckets || next < dataConf.InitialBuckets {
 		tdlog.CritNoRepeat("Bad hash table - repair ASAP %s", ht.Path)
 		return 0
 	} else {
@@ -93,10 +86,10 @@ func (ht *HashTable) lastBucket(bucket int) int {
 
 // Create and chain a new bucket.
 func (ht *HashTable) growBucket(bucket int) {
-	ht.EnsureSize(BUCKET_SIZE)
-	lastBucketAddr := ht.lastBucket(bucket) * BUCKET_SIZE
+	ht.EnsureSize(dataConf.BucketSize)
+	lastBucketAddr := ht.lastBucket(bucket) * dataConf.BucketSize
 	binary.PutVarint(ht.Buf[lastBucketAddr:lastBucketAddr+10], int64(ht.numBuckets))
-	ht.Used += BUCKET_SIZE
+	ht.Used += dataConf.BucketSize
 	ht.numBuckets++
 }
 
@@ -112,14 +105,14 @@ func (ht *HashTable) Clear() (err error) {
 // Store the entry into a vacant (invalidated or empty) place in the appropriate bucket.
 func (ht *HashTable) Put(key, val int) {
 	for bucket, entry := HashKey(key), 0; ; {
-		entryAddr := bucket*BUCKET_SIZE + BUCKET_HEADER + entry*ENTRY_SIZE
+		entryAddr := bucket*dataConf.BucketSize + dataConf.BucketHeader + entry*dataConf.EntrySize
 		if ht.Buf[entryAddr] != 1 {
 			ht.Buf[entryAddr] = 1
 			binary.PutVarint(ht.Buf[entryAddr+1:entryAddr+11], int64(key))
 			binary.PutVarint(ht.Buf[entryAddr+11:entryAddr+21], int64(val))
 			return
 		}
-		if entry++; entry == PER_BUCKET {
+		if entry++; entry == dataConf.PerBucket {
 			entry = 0
 			if bucket = ht.nextBucket(bucket); bucket == 0 {
 				ht.growBucket(HashKey(key))
@@ -138,7 +131,7 @@ func (ht *HashTable) Get(key, limit int) (vals []int) {
 		vals = make([]int, 0, limit)
 	}
 	for count, entry, bucket := 0, 0, HashKey(key); ; {
-		entryAddr := bucket*BUCKET_SIZE + BUCKET_HEADER + entry*ENTRY_SIZE
+		entryAddr := bucket*dataConf.BucketSize + dataConf.BucketHeader + entry*dataConf.EntrySize
 		entryKey, _ := binary.Varint(ht.Buf[entryAddr+1 : entryAddr+11])
 		entryVal, _ := binary.Varint(ht.Buf[entryAddr+11 : entryAddr+21])
 		if ht.Buf[entryAddr] == 1 {
@@ -151,7 +144,7 @@ func (ht *HashTable) Get(key, limit int) (vals []int) {
 		} else if entryKey == 0 && entryVal == 0 {
 			return
 		}
-		if entry++; entry == PER_BUCKET {
+		if entry++; entry == dataConf.PerBucket {
 			entry = 0
 			if bucket = ht.nextBucket(bucket); bucket == 0 {
 				return
@@ -163,7 +156,7 @@ func (ht *HashTable) Get(key, limit int) (vals []int) {
 // Flag an entry as invalid, so that Get will not return it later on.
 func (ht *HashTable) Remove(key, val int) {
 	for entry, bucket := 0, HashKey(key); ; {
-		entryAddr := bucket*BUCKET_SIZE + BUCKET_HEADER + entry*ENTRY_SIZE
+		entryAddr := bucket*dataConf.BucketSize + dataConf.BucketHeader + entry*dataConf.EntrySize
 		entryKey, _ := binary.Varint(ht.Buf[entryAddr+1 : entryAddr+11])
 		entryVal, _ := binary.Varint(ht.Buf[entryAddr+11 : entryAddr+21])
 		if ht.Buf[entryAddr] == 1 {
@@ -174,7 +167,7 @@ func (ht *HashTable) Remove(key, val int) {
 		} else if entryKey == 0 && entryVal == 0 {
 			return
 		}
-		if entry++; entry == PER_BUCKET {
+		if entry++; entry == dataConf.PerBucket {
 			entry = 0
 			if bucket = ht.nextBucket(bucket); bucket == 0 {
 				return
@@ -185,8 +178,8 @@ func (ht *HashTable) Remove(key, val int) {
 
 // Divide the entire hash table into roughly equally sized partitions, and return the start/end key range of the chosen partition.
 func GetPartitionRange(partNum, totalParts int) (start int, end int) {
-	perPart := INITIAL_BUCKETS / totalParts
-	leftOver := INITIAL_BUCKETS % totalParts
+	perPart := dataConf.InitialBuckets / totalParts
+	leftOver := dataConf.InitialBuckets % totalParts
 	start = partNum * perPart
 	if leftOver > 0 {
 		if partNum == 0 {
@@ -200,18 +193,18 @@ func GetPartitionRange(partNum, totalParts int) (start int, end int) {
 	}
 	end += start + perPart
 	if partNum == totalParts-1 {
-		end = INITIAL_BUCKETS
+		end = dataConf.InitialBuckets
 	}
 	return
 }
 
 // Collect entries all the way from "head" bucket to the end of its chained buckets.
 func (ht *HashTable) collectEntries(head int) (keys, vals []int) {
-	keys = make([]int, 0, PER_BUCKET)
-	vals = make([]int, 0, PER_BUCKET)
+	keys = make([]int, 0, dataConf.PerBucket)
+	vals = make([]int, 0, dataConf.PerBucket)
 	var entry, bucket int = 0, head
 	for {
-		entryAddr := bucket*BUCKET_SIZE + BUCKET_HEADER + entry*ENTRY_SIZE
+		entryAddr := bucket*dataConf.BucketSize + dataConf.BucketHeader + entry*dataConf.EntrySize
 		entryKey, _ := binary.Varint(ht.Buf[entryAddr+1 : entryAddr+11])
 		entryVal, _ := binary.Varint(ht.Buf[entryAddr+11 : entryAddr+21])
 		if ht.Buf[entryAddr] == 1 {
@@ -220,7 +213,7 @@ func (ht *HashTable) collectEntries(head int) (keys, vals []int) {
 		} else if entryKey == 0 && entryVal == 0 {
 			return
 		}
-		if entry++; entry == PER_BUCKET {
+		if entry++; entry == dataConf.PerBucket {
 			entry = 0
 			if bucket = ht.nextBucket(bucket); bucket == 0 {
 				return
@@ -232,7 +225,7 @@ func (ht *HashTable) collectEntries(head int) (keys, vals []int) {
 // Return all entries in the chosen partition.
 func (ht *HashTable) GetPartition(partNum, partSize int) (keys, vals []int) {
 	rangeStart, rangeEnd := GetPartitionRange(partNum, partSize)
-	prealloc := (rangeEnd - rangeStart) * PER_BUCKET
+	prealloc := (rangeEnd - rangeStart) * dataConf.PerBucket
 	keys = make([]int, 0, prealloc)
 	vals = make([]int, 0, prealloc)
 	for head := rangeStart; head < rangeEnd; head++ {

--- a/data/hashtable_test.go
+++ b/data/hashtable_test.go
@@ -18,8 +18,8 @@ func TestPutGetReopenClear(t *testing.T) {
 		t.Fatalf("Failed to open: %v", err)
 	}
 	// Test initial size information
-	if !(ht.numBuckets == INITIAL_BUCKETS && ht.Used == INITIAL_BUCKETS*BUCKET_SIZE && ht.Size == HT_FILE_GROWTH) {
-		t.Fatal("Wrong size", ht.numBuckets, INITIAL_BUCKETS, ht.Used, INITIAL_BUCKETS*BUCKET_SIZE, ht.Size, HT_FILE_GROWTH)
+	if !(ht.numBuckets == dataConf.InitialBuckets && ht.Used == dataConf.InitialBuckets*dataConf.BucketSize && ht.Size == dataConf.HTFileGrowth) {
+		t.Fatal("Wrong size", ht.numBuckets, dataConf.InitialBuckets, ht.Used, dataConf.InitialBuckets*dataConf.BucketSize, ht.Size, dataConf.HTFileGrowth)
 	}
 	for i := int(0); i < 1024*1024; i++ {
 		ht.Put(i, i)
@@ -42,7 +42,7 @@ func TestPutGetReopenClear(t *testing.T) {
 	if reopened.numBuckets != numBuckets {
 		t.Fatalf("Wrong.numBuckets")
 	}
-	if reopened.Used != numBuckets*BUCKET_SIZE {
+	if reopened.Used != numBuckets*dataConf.BucketSize {
 		t.Fatalf("Wrong UsedSize")
 	}
 	for i := int(0); i < 1024*1024; i++ {
@@ -55,7 +55,7 @@ func TestPutGetReopenClear(t *testing.T) {
 	if err = reopened.Clear(); err != nil {
 		t.Fatal(err)
 	}
-	if !(reopened.numBuckets == INITIAL_BUCKETS && reopened.Used == INITIAL_BUCKETS*BUCKET_SIZE) {
+	if !(reopened.numBuckets == dataConf.InitialBuckets && reopened.Used == dataConf.InitialBuckets*dataConf.BucketSize) {
 		t.Fatal("Did not clear the hash table")
 	}
 	allKV := make(map[int]int)

--- a/db/db.go
+++ b/db/db.go
@@ -17,6 +17,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/HouzuoGuo/tiedot/data"
 	"github.com/HouzuoGuo/tiedot/tdlog"
 )
 
@@ -35,6 +36,7 @@ type DB struct {
 // Open database and load all collections & indexes.
 func OpenDB(dbPath string) (*DB, error) {
 	rand.Seed(time.Now().UnixNano()) // document ID generation relies on this RNG
+	data.InitDataConfig(dbPath)
 	db := &DB{path: dbPath, schemaLock: new(sync.RWMutex)}
 	return db, db.load()
 }


### PR DESCRIPTION
You can create a file called data-config.json within the database directory. You only need to supply the values that differ from the defaults that were set before. When the file is not there one will be created for you.

The following can be set in the json
```
DocMaxRoom
DocHeader
Padding
ColFileGrowth
EntrySize
BucketHeader
PerBucket
HTFileGrowth
HashBits
InitialBuckets
```