### PR TITLE
Close relative files during db.Dump

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -291,6 +291,8 @@ func (db *DB) Dump(dest string) error {
 			if err != nil {
 				return err
 			}
+			_ = destFile.Close()
+			_ = src.Close()
 			tdlog.Noticef("Dump: copied file %s, size is %d", destPath, written)
 		}
 		return nil


### PR DESCRIPTION
This is a follow up of issue #165, need to close file explicitly or we'll have trouble if db is created on NFS shares