### PR TITLE
db: remove extra type assertion

### DIFF
--- a/db/doc.go
+++ b/db/doc.go
@@ -30,9 +30,9 @@ func GetIn(doc interface{}, path []string) (ret []interface{}) {
 			return nil
 		}
 	}
-	switch thing.(type) {
+	switch thing := thing.(type) {
 	case []interface{}:
-		return append(ret, thing.([]interface{})...)
+		return append(ret, thing...)
 	default:
 		return append(ret, thing)
 	}


### PR DESCRIPTION
Remove extra type assertion by assigning type switch var.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>